### PR TITLE
Colocar bairro

### DIFF
--- a/functions/lib/mandabem/create-tag.js
+++ b/functions/lib/mandabem/create-tag.js
@@ -37,6 +37,7 @@ module.exports = (apiId, apiKey, order, refId) => {
             data.destinatario = shippingLine.to.name
             data.cep = shippingLine.to.zip.replace(/\D/g, '')
             data.logradouro = shippingLine.to.street
+            data.bairro = shippingLine.to.borough
             data.numero = shippingLine.to.number || 'SN'
             if (shippingLine.to.complement) {
               data.complemento = shippingLine.to.complement


### PR DESCRIPTION
Os pedidos não estão indo com bairro, na documentação nao tinha esse nos parâmetros do pedido, como teve reclamação, entrei em contato lá e o parametro era bairro.