### PR TITLE
feat(ecom-config): add config app data to posting deadline

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -170,6 +170,35 @@ const app = {
       },
       hide: true
     },
+    posting_deadline: {
+      schema: {
+        title: 'Prazo de postagem',
+        type: 'object',
+        required: ['days'],
+        additionalProperties: false,
+        properties: {
+          days: {
+            type: 'integer',
+            default: 3,
+            minimum: 0,
+            maximum: 999999,
+            title: 'Número de dias',
+            description: 'Dias de prazo para postar os produtos após a compra'
+          },
+          working_days: {
+            type: 'boolean',
+            default: true,
+            title: 'Dias úteis'
+          },
+          after_approval: {
+            type: 'boolean',
+            default: true,
+            title: 'Após aprovação do pagamento'
+          }
+        }
+      },
+      hide: false
+    },
     shipping_rules: {
       schema: {
         title: 'Regras de envio',


### PR DESCRIPTION
At calculate shipping we already have posting deadline with spread operator. So, we just need to allow the configuration at the app